### PR TITLE
Use 0xFFF instead of 999999999999 (0xE8D4A50FFF).

### DIFF
--- a/php.ini
+++ b/php.ini
@@ -7,7 +7,7 @@ docref_root = 0
 docref_ext = 0
 track_errors = true
 report_memleaks = true
-error_reporting = 999999999999
+error_reporting = 4095 ; 0xFFF, no need to go crazy.
 log_errors_max_len = 0
 error_log = /var/log/php/php_error.log
 


### PR DESCRIPTION
error_logging value is a bit mask, the highest usable number is 0x7FFF (E_ALL or 32767). You're just setting everything up to E_RECOVERABLE_ERROR and making it hard to read.